### PR TITLE
Add OpenAI client and update quiz endpoint

### DIFF
--- a/client/src/pages/api/quiz.ts
+++ b/client/src/pages/api/quiz.ts
@@ -1,11 +1,19 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { openai } from '../../../shared/openai'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  switch (req.method) {
-    case 'POST':
-      // start quiz or record answer
-      return res.status(200).json({ message: 'quiz placeholder' })
-    default:
-      return res.status(405).end()
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { role } = req.body
+  try {
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'You are an interview prep assistant.' },
+        { role: 'user', content: `Generate 5 ${role} interview questions.` },
+      ],
+    })
+    res.status(200).json({ questions: completion.data.choices[0].message?.content })
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ error: 'Failed to generate questions' })
   }
 }

--- a/shared/openai.ts
+++ b/shared/openai.ts
@@ -1,0 +1,8 @@
+import 'dotenv/config'
+import { Configuration, OpenAIApi } from 'openai'
+
+const config = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+})
+
+export const openai = new OpenAIApi(config)


### PR DESCRIPTION
## Summary
- add a shared helper to initialize the OpenAI API client
- wire the quiz API route to generate questions with OpenAI
- note: installing `dotenv` failed due to lack of internet access

## Testing
- `npm install dotenv` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6865aac96efc8321abd4ef1a1ee5bc1c