### PR TITLE
Add profile setup form and user API

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "bcryptjs": "^3.0.2",
+        "formidable": "^3.5.4",
         "jsonwebtoken": "^9.0.2",
         "next": "14.2.0",
         "react": "^18.2.0",
@@ -498,6 +499,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -572,6 +585,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1633,6 +1655,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2353,6 +2381,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/didyoumean": {
@@ -3309,6 +3347,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/fraction.js": {
@@ -5296,7 +5351,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7558,7 +7612,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yallist": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",
+    "formidable": "^3.5.4",
     "jsonwebtoken": "^9.0.2",
     "next": "14.2.0",
     "react": "^18.2.0",

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function ProfilePage() {
+  const [avatar, setAvatar] = useState<File | null>(null)
+  const [username, setUsername] = useState('')
+  const [bio, setBio] = useState('')
+  const [role, setRole] = useState('')
+  const router = useRouter()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!avatar) {
+      alert('Please select an avatar')
+      return
+    }
+    const form = new FormData()
+    form.append('avatar', avatar)
+    form.append('username', username)
+    form.append('bio', bio)
+    form.append('role', role)
+
+    const token = localStorage.getItem('token')
+    const res = await fetch('/api/user', {
+      method: 'POST',
+      headers: {
+        'x-user-id': token ? JSON.parse(atob(token.split('.')[1])).id : ''
+      },
+      body: form,
+    })
+
+    if (res.ok) {
+      router.push('/quiz')
+    } else {
+      alert('Profile update failed')
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleSubmit} className="space-y-4" encType="multipart/form-data">
+        <h1 className="text-2xl font-bold">Complete Your Profile</h1>
+        <input type="file" accept="image/*" onChange={(e) => setAvatar(e.target.files?.[0] || null)} />
+        <input
+          type="text"
+          placeholder="Username"
+          className="border p-2 w-full"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <textarea
+          placeholder="Bio"
+          className="border p-2 w-full"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Role"
+          className="border p-2 w-full"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2">Save</button>
+      </form>
+    </main>
+  )
+}

--- a/client/src/pages/api/user.ts
+++ b/client/src/pages/api/user.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import formidable from 'formidable'
+import { promises as fs } from 'fs'
+import path from 'path'
+import prisma from '../../../shared/db'
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end()
+  }
+
+  const form = formidable({ multiples: false })
+
+  form.parse(req, async (err, fields, files) => {
+    if (err) {
+      console.error(err)
+      return res.status(500).json({ error: 'Form parse error' })
+    }
+
+    const { username, bio, role } = fields
+    const file = Array.isArray(files.avatar) ? files.avatar[0] : files.avatar
+
+    if (!username || !bio || !role || !file) {
+      return res.status(400).json({ error: 'Missing fields' })
+    }
+
+    try {
+      const uploadsDir = path.join(process.cwd(), 'public', 'uploads')
+      await fs.mkdir(uploadsDir, { recursive: true })
+      const fileExt = path.extname(file.originalFilename || '')
+      const fileName = `${Date.now()}_${Math.random().toString(16).slice(2)}${fileExt}`
+      const dest = path.join(uploadsDir, fileName)
+      await fs.copyFile(file.filepath, dest)
+
+      const userId = req.headers['x-user-id'] as string | undefined
+      if (!userId) {
+        return res.status(401).json({ error: 'Missing user id' })
+      }
+
+      await prisma.user.update({
+        where: { id: userId },
+        data: { username: String(username), role: String(role), avatarUrl: `/uploads/${fileName}`, bio: String(bio) },
+      })
+      return res.status(200).json({ avatarUrl: `/uploads/${fileName}` })
+    } catch (e) {
+      console.error(e)
+      return res.status(500).json({ error: 'Failed to save profile' })
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- allow file uploads from users and store avatars
- add profile setup page for collecting avatar, bio and role
- add API endpoint for updating user profile

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865b9d0aeac83219bb0c460974988d1