### PR TITLE
Add customizable quiz form and API updates

### DIFF
--- a/client/src/app/quiz/page.tsx
+++ b/client/src/app/quiz/page.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function QuizStartPage() {
+  const [role, setRole] = useState('')
+  const [techStack, setTechStack] = useState('')
+  const [technology, setTechnology] = useState('')
+  const [listingDescription, setListingDescription] = useState('')
+  const [jobDescriptionUrl, setJobDescriptionUrl] = useState('')
+  const [questions, setQuestions] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('/api/quiz', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        role,
+        techStack,
+        technology,
+        listingDescription,
+        jobDescriptionUrl,
+      }),
+    })
+
+    if (res.ok) {
+      const data = await res.json()
+      setQuestions(data.questions)
+    } else {
+      alert('Failed to start quiz')
+    }
+  }
+
+  return (
+    <main className="flex flex-col min-h-screen items-center p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md">
+        <h1 className="text-2xl font-bold">Start Quiz</h1>
+        <input
+          type="text"
+          placeholder="Role"
+          className="border p-2 w-full"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Tech Stack"
+          className="border p-2 w-full"
+          value={techStack}
+          onChange={(e) => setTechStack(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Technologies"
+          className="border p-2 w-full"
+          value={technology}
+          onChange={(e) => setTechnology(e.target.value)}
+        />
+        <textarea
+          placeholder="Listing Description"
+          className="border p-2 w-full"
+          value={listingDescription}
+          onChange={(e) => setListingDescription(e.target.value)}
+        />
+        <input
+          type="url"
+          placeholder="Job Description URL"
+          className="border p-2 w-full"
+          value={jobDescriptionUrl}
+          onChange={(e) => setJobDescriptionUrl(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">
+          Generate Quiz
+        </button>
+      </form>
+      {questions && (
+        <div className="mt-6 whitespace-pre-line w-full max-w-md border p-4">
+          {questions}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/client/src/pages/api/quiz.ts
+++ b/client/src/pages/api/quiz.ts
@@ -1,17 +1,53 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { openai } from '../../../shared/openai'
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { role } = req.body
+interface QuizRequest {
+  role?: string
+  techStack?: string
+  technology?: string
+  listingDescription?: string
+  jobDescriptionUrl?: string
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const {
+    role,
+    techStack,
+    technology,
+    listingDescription,
+    jobDescriptionUrl,
+  } = req.body as QuizRequest
+
+  let jobDescription = ''
+  if (jobDescriptionUrl) {
+    try {
+      const resp = await fetch(jobDescriptionUrl)
+      jobDescription = await resp.text()
+    } catch (err) {
+      console.error('Failed to fetch job description', err)
+    }
+  }
+
+  const prompt = `Generate 5 interview questions for a ${role || 'developer'} role.\n` +
+    (techStack ? `Tech Stack: ${techStack}.\n` : '') +
+    (technology ? `Technologies: ${technology}.\n` : '') +
+    (listingDescription ? `Listing Description: ${listingDescription}.\n` : '') +
+    (jobDescription ? `Job Description: ${jobDescription.slice(0, 1000)}\n` : '')
+
   try {
     const completion = await openai.createChatCompletion({
       model: 'gpt-4o-mini',
       messages: [
         { role: 'system', content: 'You are an interview prep assistant.' },
-        { role: 'user', content: `Generate 5 ${role} interview questions.` },
+        { role: 'user', content: prompt },
       ],
     })
-    res.status(200).json({ questions: completion.data.choices[0].message?.content })
+    res
+      .status(200)
+      .json({ questions: completion.data.choices[0].message?.content })
   } catch (error) {
     console.error(error)
     res.status(500).json({ error: 'Failed to generate questions' })


### PR DESCRIPTION
## Summary
- extend quiz API to accept role, tech stack, technology, listing description and job URL
- add a new `/quiz` page with a start form using the new fields

## Testing
- `npm install`
- `npm run build` *(fails: Module not found '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_6865bc4ff454832180c2f15bdf1fd5e6