### PR TITLE
Add answer evaluation and auth-aware navbar

### DIFF
--- a/client/src/app/quiz/session/[id]/page.module.css
+++ b/client/src/app/quiz/session/[id]/page.module.css
@@ -7,3 +7,7 @@
 .buttons {
   @apply mt-4 space-x-4;
 }
+
+.feedback {
+  @apply mt-4 border p-4 w-full max-w-lg;
+}

--- a/client/src/app/quiz/session/[id]/page.tsx
+++ b/client/src/app/quiz/session/[id]/page.tsx
@@ -16,6 +16,10 @@ export default function QuizSessionPage() {
   const [index, setIndex] = useState(0)
   const [questions, setQuestions] = useState<Question[]>([])
   const [loading, setLoading] = useState(true)
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [results, setResults] = useState<Record<string, { correct: boolean; explanation?: string }>>({})
+  const [explain, setExplain] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     const fetchSession = async () => {
@@ -51,11 +55,68 @@ export default function QuizSessionPage() {
   }
 
   const current = questions[index]
+
+  const handleCheck = async () => {
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          questionId: current.id,
+          answer: answers[current.id] || '',
+          explain,
+        }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setResults((r) => ({ ...r, [current.id]: data }))
+      } else {
+        alert('Failed to check answer')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
   return (
     <main className={styles.main}>
       <div className={styles.card}>
         <p>{current.prompt}</p>
       </div>
+      <textarea
+        className="border p-2 w-full max-w-lg mt-4"
+        value={answers[current.id] || ''}
+        onChange={(e) =>
+          setAnswers((a) => ({ ...a, [current.id]: e.target.value }))
+        }
+      />
+      <label className="mt-2 flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={explain}
+          onChange={(e) => setExplain(e.target.checked)}
+        />
+        Request explanation
+      </label>
+      <button
+        onClick={handleCheck}
+        disabled={submitting}
+        className="bg-green-500 text-white px-3 py-1 mt-2 disabled:opacity-50"
+      >
+        Check Answer
+      </button>
+      {results[current.id] && (
+        <div className={styles.feedback}>
+          <p
+            className={`font-bold ${results[current.id].correct ? 'text-green-600' : 'text-red-600'}`}
+          >
+            {results[current.id].correct ? 'Correct' : 'Incorrect'}
+          </p>
+          {results[current.id].explanation && (
+            <p className="mt-2">{results[current.id].explanation}</p>
+          )}
+        </div>
+      )}
       <div className={styles.buttons}>
         <button
           disabled={index === 0}

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,14 +1,42 @@
+'use client'
+
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 
 export default function Navbar() {
+  const [loggedIn, setLoggedIn] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    setLoggedIn(!!localStorage.getItem('token'))
+  }, [])
+
+  const handleSignOut = async () => {
+    localStorage.removeItem('token')
+    await fetch('/api/auth', { method: 'DELETE' })
+    setLoggedIn(false)
+    router.push('/login')
+  }
+
   return (
     <nav className="bg-gray-800 text-white p-4 flex flex-col sm:flex-row items-center sm:justify-between gap-4">
       <div className="text-lg font-bold">AI Quizzer</div>
       <div className="flex flex-col sm:flex-row gap-4 items-center">
         <Link href="/">Home</Link>
-        <Link href="/login">Login</Link>
-        <Link href="/signup">Sign Up</Link>
-        <Link href="/quiz">Quiz</Link>
+        {loggedIn ? (
+          <>
+            <Link href="/profile">Profile</Link>
+            <Link href="/quiz">Quiz</Link>
+            <button onClick={handleSignOut}>Sign Out</button>
+          </>
+        ) : (
+          <>
+            <Link href="/login">Login</Link>
+            <Link href="/signup">Sign Up</Link>
+            <Link href="/quiz">Quiz</Link>
+          </>
+        )}
       </div>
     </nav>
   )

--- a/client/src/pages/api/answer.ts
+++ b/client/src/pages/api/answer.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { openai } from '../../lib/openai'
+import prisma from '../../lib/db'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end()
+  }
+
+  const { questionId, answer, explain } = req.body as {
+    questionId?: string
+    answer?: string
+    explain?: boolean
+  }
+
+  if (!questionId || !answer) {
+    return res.status(400).json({ error: 'Missing fields' })
+  }
+
+  try {
+    const question = await prisma.question.findUnique({
+      where: { id: questionId },
+      include: { session: true },
+    })
+    if (!question) {
+      return res.status(404).json({ error: 'Question not found' })
+    }
+
+    const prompt = `You are an expert technical interviewer evaluating a candidate's answer.\\n` +
+      `Question: ${question.prompt}\\n` +
+      `Candidate Answer: ${answer}\\n` +
+      `Respond in JSON with \\"correct\\" (true or false)` +
+      (explain ? ` and \\"explanation\\" describing why.` : '.')
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      response_format: { type: 'json_object' },
+      messages: [{ role: 'user', content: prompt }],
+    })
+
+    const parsed = JSON.parse(completion.choices[0].message?.content || '{}')
+    const correct = !!parsed.correct
+    await prisma.question.update({
+      where: { id: questionId },
+      data: { userCorrect: correct },
+    })
+    if (correct) {
+      await prisma.session.update({
+        where: { id: question.sessionId },
+        data: { correctCount: { increment: 1 } },
+      })
+    }
+
+    res.status(200).json({ correct, explanation: parsed.explanation })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'Failed to check answer' })
+  }
+}


### PR DESCRIPTION
## Summary
- display profile link and Sign Out if logged in
- add API route to evaluate question answers with OpenAI
- allow checking answers in quiz sessions with optional explanation
- style feedback on quiz session page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c5e0f7948321b849b00f49876214