### PR TITLE
Enhance quiz flow with hints, answers and summary

### DIFF
--- a/client/src/app/quiz/session/[id]/page.module.css
+++ b/client/src/app/quiz/session/[id]/page.module.css
@@ -2,12 +2,24 @@
   @apply flex flex-col flex-grow items-center p-4;
 }
 .card {
-  @apply border p-4 w-full max-w-lg transition-all;
+  @apply border p-4 w-full max-w-lg transition-all bg-white rounded shadow;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 .buttons {
   @apply mt-4 space-x-4;
 }
 
 .feedback {
-  @apply mt-4 border p-4 w-full max-w-lg;
+  @apply mt-4 border p-4 w-full max-w-lg rounded;
 }

--- a/client/src/app/quiz/session/[id]/summary/page.module.css
+++ b/client/src/app/quiz/session/[id]/summary/page.module.css
@@ -1,0 +1,7 @@
+.main {
+  @apply flex flex-col flex-grow items-center p-4;
+}
+
+.card {
+  @apply border p-4 w-full bg-white rounded shadow;
+}

--- a/client/src/app/quiz/session/[id]/summary/page.tsx
+++ b/client/src/app/quiz/session/[id]/summary/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import styles from './page.module.css'
+
+interface Question {
+  id: string
+  prompt: string
+  userCorrect?: boolean
+}
+
+interface SessionData {
+  questions: Question[]
+  correctCount: number
+  totalQuestions: number
+}
+
+export default function QuizSummaryPage() {
+  const params = useParams() as Record<string, string>
+  const id = params.id
+  const [data, setData] = useState<SessionData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchSession = async () => {
+      const res = await fetch(`/api/session/${id}`)
+      if (res.ok) {
+        setData(await res.json())
+      }
+      setLoading(false)
+    }
+    fetchSession()
+  }, [id])
+
+  if (loading) {
+    return (
+      <main className={styles.main}>
+        <p>Loading summary...</p>
+      </main>
+    )
+  }
+
+  if (!data) {
+    return (
+      <main className={styles.main}>
+        <p>Session not found.</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className={styles.main}>
+      <h1 className="text-2xl font-bold mb-4">Quiz Summary</h1>
+      <p className="mb-4">
+        Correct {data.correctCount} of {data.totalQuestions}
+      </p>
+      <ul className="space-y-2 w-full max-w-lg">
+        {data.questions.map((q) => (
+          <li
+            key={q.id}
+            className={`${styles.card} ${q.userCorrect ? 'border-green-500' : 'border-red-500'}`}
+          >
+            <p>{q.prompt}</p>
+            <p className="font-bold">
+              {q.userCorrect ? 'Correct' : 'Incorrect'}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- show hint and answer toggles inside quiz session
- track correct/incorrect counts and style questions as answered
- navigate automatically to new summary page when quiz is done
- embed Tenor GIF when loading a session
- animate quiz cards and add summary page styling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865ca74361c8321865ba264e3db7b3c