### PR TITLE
Add user bio migration and logging fixes

### DIFF
--- a/client/prisma/migrations/20250703013000_add_bio_to_user/migration.sql
+++ b/client/prisma/migrations/20250703013000_add_bio_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "bio" TEXT;

--- a/client/src/pages/api/auth.ts
+++ b/client/src/pages/api/auth.ts
@@ -6,6 +6,7 @@ import prisma from '../../lib/db'
 const JWT_SECRET = process.env.JWT_SECRET || 'secret'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  console.log(`[API] ${req.method} ${req.url}`)
   switch (req.method) {
     case 'POST':
       const { action, email, password, username } = req.body

--- a/client/src/pages/api/quiz.ts
+++ b/client/src/pages/api/quiz.ts
@@ -15,6 +15,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  console.log(`[API] ${req.method} ${req.url}`)
   const {
     role,
     techStack,
@@ -72,9 +73,12 @@ export default async function handler(
       ],
     })
 
-    const raw = completion.choices[0].message?.content || '[]'
-    const parsed = JSON.parse(raw)
-    const prompts = Array.isArray(parsed) ? parsed : []
+    let raw = completion.choices[0].message?.content || '[]'
+    raw = raw.replace(/```[a-z]*\n?/, '').replace(/```/g, '').trim()
+    console.log('Raw AI response:', raw)
+    const questions = JSON.parse(raw)
+    console.log('Parsed questions:', questions)
+    const prompts = Array.isArray(questions) ? questions : []
 
     const session = await prisma.session.create({
       data: {

--- a/client/src/pages/api/user/update.ts
+++ b/client/src/pages/api/user/update.ts
@@ -7,6 +7,7 @@ import prisma from '../../../lib/db'
 export const config = { api: { bodyParser: false } }
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  console.log(`[API] ${req.method} ${req.url}`)
   if (req.method !== 'POST') return res.status(405).end()
 
   const form = formidable({ multiples: false })
@@ -32,18 +33,21 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       const userId = req.headers['x-user-id'] as string | undefined
       if (!userId) return res.status(401).json({ error: 'Missing user id' })
 
+      const avatarUrl = `/uploads/${fileName}`
+      console.log('Updating user:', { userId, username, bio, avatarUrl })
+
       const user = await prisma.user.update({
         where: { id: userId },
         data: {
           username: String(username),
           bio: String(bio),
-          avatarUrl: `/uploads/${fileName}`,
+          avatarUrl,
         },
       })
 
       return res.status(200).json({ success: true, user: { username: user.username, bio: user.bio, avatarUrl: user.avatarUrl } })
-    } catch (e) {
-      console.error(e)
+    } catch (error) {
+      console.error('USER UPDATE ERROR:', error)
       return res.status(500).json({ error: 'Failed to save profile' })
     }
   })


### PR DESCRIPTION
## Summary
- add migration to add `bio` column
- sanitize AI output in quiz API and add logging
- add API request logging in auth and user update routes
- improve error handling in user update route

## Testing
- `npm test --prefix client` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865dea7e3488321ac526b1d4cc8d8ea