### PR TITLE
Add quiz retake options and editable profile

### DIFF
--- a/client/src/app/profile/__tests__/page.test.tsx
+++ b/client/src/app/profile/__tests__/page.test.tsx
@@ -8,15 +8,18 @@ jest.mock('next/navigation', () => ({
 global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })) as any
 
 describe('Profile page', () => {
-  it('renders inputs and button', () => {
+  it('shows edit button initially and displays form after clicking', () => {
     render(<ProfilePage />)
+    expect(screen.getByText('Edit Profile')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Username')).toBeNull()
+    fireEvent.click(screen.getByText('Edit Profile'))
     expect(screen.getByPlaceholderText('Username')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Bio')).toBeInTheDocument()
     expect(screen.getByText('Save')).toBeInTheDocument()
   })
 
   it('submits form data', async () => {
     render(<ProfilePage />)
+    fireEvent.click(screen.getByText('Edit Profile'))
     const file = new File(['a'], 'avatar.png', { type: 'image/png' })
     fireEvent.change(screen.getByLabelText(/avatar/i), { target: { files: [file] } })
     fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'bob' } })

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -11,6 +11,7 @@ export default function ProfilePage() {
   const [username, setUsername] = useState('')
   const [bio, setBio] = useState('')
   const [sessions, setSessions] = useState<any[]>([])
+  const [editing, setEditing] = useState(false)
   const router = useRouter()
 
   useEffect(() => {
@@ -61,15 +62,17 @@ export default function ProfilePage() {
       if (url) setAvatarUrl(url)
       setAvatar(null)
       alert('Profile updated')
+      setEditing(false)
     } else {
       alert('Profile update failed')
     }
   }
 
-    return (
-      <main className={styles.main}>
+  return (
+    <main className={styles.main}>
+      {editing ? (
         <form onSubmit={handleSubmit} className="space-y-4" encType="multipart/form-data">
-          <h1 className="text-2xl font-bold">Complete Your Profile</h1>
+          <h1 className="text-2xl font-bold">Edit Profile</h1>
           {avatarUrl && (
             <img src={avatarUrl} alt="avatar" className="h-24 w-24 rounded-full" />
           )}
@@ -92,8 +95,21 @@ export default function ProfilePage() {
             value={bio}
             onChange={(e) => setBio(e.target.value)}
           />
-          <button type="submit" className="bg-blue-500 text-white px-4 py-2">Save</button>
+          <div className="flex gap-2">
+            <button type="submit" className="bg-blue-500 text-white px-4 py-2">Save</button>
+            <button type="button" className="px-4 py-2 border" onClick={() => setEditing(false)}>Cancel</button>
+          </div>
         </form>
+      ) : (
+        <div className="space-y-4 text-center">
+          {avatarUrl && (
+            <img src={avatarUrl} alt="avatar" className="h-24 w-24 rounded-full mx-auto" />
+          )}
+          <h1 className="text-2xl font-bold">{username}</h1>
+          <p>{bio}</p>
+          <button className="bg-blue-500 text-white px-4 py-2" onClick={() => setEditing(true)}>Edit Profile</button>
+        </div>
+      )}
         {sessions.length > 0 && (
           <section className="mt-8 w-full max-w-md">
             <h2 className="text-xl font-bold mb-2">Open Quizzes</h2>

--- a/client/src/app/quiz/session/[id]/summary/page.tsx
+++ b/client/src/app/quiz/session/[id]/summary/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import styles from './page.module.css'
 
 interface Question {
@@ -19,8 +19,24 @@ interface SessionData {
 export default function QuizSummaryPage() {
   const params = useParams() as Record<string, string>
   const id = params.id
+  const router = useRouter()
   const [data, setData] = useState<SessionData | null>(null)
   const [loading, setLoading] = useState(true)
+
+  const handleRetake = async () => {
+    const res = await fetch(`/api/session/${id}/reset`, { method: 'POST' })
+    if (res.ok) {
+      router.push(`/quiz/session/${id}`)
+    }
+  }
+
+  const handleNew = async () => {
+    const res = await fetch(`/api/session/${id}/new`, { method: 'POST' })
+    if (res.ok) {
+      const data = await res.json()
+      router.push(`/quiz/session/${data.sessionId}`)
+    }
+  }
 
   useEffect(() => {
     const fetchSession = async () => {
@@ -68,6 +84,20 @@ export default function QuizSummaryPage() {
           </li>
         ))}
       </ul>
+      <div className="flex gap-2 mt-4">
+        <button
+          onClick={handleRetake}
+          className="bg-blue-500 text-white px-3 py-1"
+        >
+          Retake Quiz
+        </button>
+        <button
+          onClick={handleNew}
+          className="bg-green-500 text-white px-3 py-1"
+        >
+          New Questions
+        </button>
+      </div>
     </main>
   )
 }

--- a/client/src/pages/api/session/[id]/index.ts
+++ b/client/src/pages/api/session/[id]/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import prisma from '../../../lib/db'
+import prisma from '../../../../lib/db'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query

--- a/client/src/pages/api/session/[id]/new.ts
+++ b/client/src/pages/api/session/[id]/new.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import prisma from '../../../../lib/db'
+import { openai } from '../../../../lib/openai'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end()
+  }
+  const { id } = req.query
+  if (!id || Array.isArray(id)) {
+    return res.status(400).json({ error: 'Invalid session id' })
+  }
+  try {
+    const session = await prisma.session.findUnique({ where: { id } })
+    if (!session) {
+      return res.status(404).json({ error: 'Session not found' })
+    }
+
+    const prompt = `Generate 5 interview questions for a ${session.role} role.\n` +
+      (session.multipleChoice
+        ? '\nReturn JSON array where each item has "prompt", "hint", "answer", and "options" (an array of 6 strings with the first option as the correct answer).'
+        : '\nReturn JSON array where each item has "prompt", "hint", and "answer".')
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: 'You are an interview prep assistant.' },
+        { role: 'user', content: prompt },
+      ],
+    })
+
+    let raw = completion.choices[0].message?.content || '[]'
+    raw = raw.replace(/```[a-z]*\n?/, '').replace(/```/g, '').trim()
+    const questions = JSON.parse(raw)
+    const shuffle = (arr: any[]) => {
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[arr[i], arr[j]] = [arr[j], arr[i]]
+      }
+    }
+    const prompts = Array.isArray(questions) ? questions : []
+
+    const newSession = await prisma.session.create({
+      data: {
+        userId: session.userId,
+        role: session.role,
+        multipleChoice: session.multipleChoice,
+        totalQuestions: prompts.length,
+        correctCount: 0,
+        questions: {
+          create: prompts.map((p: any) => {
+            const opts = p.options ? [...p.options] : null
+            if (opts) shuffle(opts)
+            return {
+              prompt: p.prompt || p,
+              hint: p.hint || '',
+              modelAnswer: p.answer || '',
+              options: opts ? JSON.stringify(opts) : null,
+            }
+          }),
+        },
+      },
+    })
+
+    res.status(200).json({ sessionId: newSession.id })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'Failed to create new session' })
+  }
+}

--- a/client/src/pages/api/session/[id]/reset.ts
+++ b/client/src/pages/api/session/[id]/reset.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import prisma from '../../../../lib/db'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end()
+  }
+  const { id } = req.query
+  if (!id || Array.isArray(id)) {
+    return res.status(400).json({ error: 'Invalid session id' })
+  }
+  try {
+    await prisma.question.updateMany({
+      where: { sessionId: id },
+      data: { userCorrect: null },
+    })
+    await prisma.session.update({
+      where: { id },
+      data: { correctCount: 0 },
+    })
+    res.status(200).json({ success: true })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'Failed to reset session' })
+  }
+}


### PR DESCRIPTION
## Summary
- add API routes to reset and regenerate quiz sessions
- update quiz summary page with Retake Quiz and New Questions buttons
- make profile page editable only when clicking Edit Profile
- update profile page tests for new edit behavior

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865eabefae883218b7de07ee0e2be31