### PR TITLE
Add loader animation

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@keyframes l2 {
+  to { transform: rotate(1turn); }
+}
+@keyframes l2-reverse {
+  to { transform: rotate(-1turn); }
+}
+.animate-l2 {
+  animation: l2 1s linear infinite;
+}
+.animate-l2-reverse {
+  animation: l2-reverse 1s linear infinite;
+}

--- a/client/src/app/quiz/page.tsx
+++ b/client/src/app/quiz/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import styles from './page.module.css'
+import Loader from '../../components/Loader'
 
 export default function QuizStartPage() {
   const [role, setRole] = useState('')
@@ -111,12 +112,9 @@ export default function QuizStartPage() {
         </button>
       </form>
       {loading && (
-        <div className="mt-4 text-center" data-testid="loading-gif">
-          <img
-            src="https://media.tenor.com/w7SZOxb2A_MAAAAi/south-park-randy.gif"
-            alt="loading"
-            className="mx-auto" />
-          <p>Generating questions...</p>
+        <div className="mt-4 text-center" data-testid="loading">
+          <Loader />
+          <p className="mt-2">Generating questions...</p>
         </div>
       )}
       {error && <p className="mt-2 text-red-500">{error}</p>}

--- a/client/src/app/quiz/session/[id]/page.tsx
+++ b/client/src/app/quiz/session/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import styles from './page.module.css'
+import Loader from '../../../../components/Loader'
 
 interface Question {
   id: string
@@ -61,11 +62,7 @@ export default function QuizSessionPage() {
   if (loading) {
     return (
       <main className={styles.main}>
-        <img
-          src="https://media.tenor.com/w7SZOxb2A_MAAAAi/south-park-randy.gif"
-          alt="loading"
-          className="mx-auto"
-        />
+        <Loader />
       </main>
     )
   }

--- a/client/src/components/Loader.tsx
+++ b/client/src/components/Loader.tsx
@@ -1,0 +1,17 @@
+// Loader.tsx
+export default function Loader() {
+  return (
+    <div className="
+      w-10 aspect-square rounded-full border-2 border-current text-black
+      box-border relative origin-left animate-l2
+      before:content-[''] before:absolute before:inset-0_0_auto before:m-auto
+      before:w-1/2 before:aspect-square before:rounded-full before:border-2
+      before:border-current before:box-content
+      before:origin-[50%_calc(100%_-_4px)] before:animate-l2
+      after:content-[''] after:absolute after:inset-auto_0_calc(100%_+_2px)
+      after:m-auto after:w-1/2 after:aspect-square after:rounded-full
+      after:border-2 after:border-current after:box-content
+      after:origin-[50%_calc(200%_-_2px)] after:animate-l2-reverse
+    " />
+  );
+}


### PR DESCRIPTION
## Summary
- implement a reusable Loader component
- add keyframe animations to global styles
- replace GIF loaders with Loader component in quiz pages

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865fb4d8c1c8321a8c699da981bedbf