### PR TITLE
Improve mobile navbar and loader spacing

### DIFF
--- a/client/src/components/Loader.tsx
+++ b/client/src/components/Loader.tsx
@@ -2,7 +2,7 @@
 export default function Loader() {
   return (
     <div className="
-      w-10 aspect-square rounded-full border-2 border-current text-black
+      m-4 w-10 aspect-square rounded-full border-2 border-current text-black
       box-border relative origin-left animate-l2
       before:content-[''] before:absolute before:inset-0_0_auto before:m-auto
       before:w-1/2 before:aspect-square before:rounded-full before:border-2

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ export default function Navbar() {
   const [loggedIn, setLoggedIn] = useState(false)
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
   const [username, setUsername] = useState('')
+  const [menuOpen, setMenuOpen] = useState(false)
   const router = useRouter()
 
   useEffect(() => {
@@ -36,25 +37,86 @@ export default function Navbar() {
   }
 
   return (
-    <nav className="bg-gray-800 text-white p-4 flex flex-col sm:flex-row items-center sm:justify-between gap-4">
-      <div className="text-lg font-bold">AI Quizzer</div>
-      <div className="flex flex-col sm:flex-row gap-4 items-center">
-        <Link href="/">Home</Link>
+    <nav className="bg-gray-800 text-white p-4 flex flex-col sm:flex-row items-center sm:justify-between gap-2">
+      <div className="w-full flex justify-between items-center">
+        <div className="text-lg font-bold">AI Quizzer</div>
+        <button
+          className="sm:hidden p-2"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Toggle navigation"
+        >
+          {menuOpen ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+          )}
+        </button>
+      </div>
+      <div
+        className={`${
+          menuOpen ? 'flex' : 'hidden'
+        } flex-col sm:flex sm:flex-row gap-4 items-center w-full sm:w-auto`}
+      >
+        <Link href="/" onClick={() => setMenuOpen(false)}>
+          Home
+        </Link>
         {loggedIn ? (
           <>
-            <Link href="/profile">Profile</Link>
-            <Link href="/quiz">Quiz</Link>
+            <Link href="/profile" onClick={() => setMenuOpen(false)}>
+              Profile
+            </Link>
+            <Link href="/quiz" onClick={() => setMenuOpen(false)}>
+              Quiz
+            </Link>
             {avatarUrl && (
               <img src={avatarUrl} alt="avatar" className="h-8 w-8 rounded-full" />
             )}
             {username && <span className="ml-1">{username}</span>}
-            <button onClick={handleSignOut}>Sign Out</button>
+            <button
+              onClick={() => {
+                setMenuOpen(false)
+                handleSignOut()
+              }}
+            >
+              Sign Out
+            </button>
           </>
         ) : (
           <>
-            <Link href="/login">Login</Link>
-            <Link href="/signup">Sign Up</Link>
-            <Link href="/quiz">Quiz</Link>
+            <Link href="/login" onClick={() => setMenuOpen(false)}>
+              Login
+            </Link>
+            <Link href="/signup" onClick={() => setMenuOpen(false)}>
+              Sign Up
+            </Link>
+            <Link href="/quiz" onClick={() => setMenuOpen(false)}>
+              Quiz
+            </Link>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add hamburger toggle for Navbar
- hide/show navigation links on small screens
- add margin around loader animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686610bc3d708321a3ffc3cd1f95039c