### PR TITLE
Fix auth flow with profile loading screen

### DIFF
--- a/client/src/app/loading/page.module.css
+++ b/client/src/app/loading/page.module.css
@@ -1,0 +1,3 @@
+.main {
+  @apply flex flex-col items-center justify-center flex-grow;
+}

--- a/client/src/app/loading/page.tsx
+++ b/client/src/app/loading/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+import Loader from '../../components/Loader'
+import styles from './page.module.css'
+
+export default function LoadingScreen() {
+  const router = useRouter()
+  const params = useSearchParams()
+
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    if (!token) {
+      router.replace('/login')
+      return
+    }
+    const userId = JSON.parse(atob(token.split('.')[1])).id
+    fetch('/api/user/profile', { headers: { 'x-user-id': userId } })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then(() => {
+        const next = params.get('next') || '/dashboard'
+        router.replace(next)
+      })
+      .catch(() => {
+        localStorage.removeItem('token')
+        router.replace('/login')
+      })
+  }, [router, params])
+
+  return (
+    <main className={styles.main}>
+      <Loader />
+      <p className="mt-2">Loading profile...</p>
+    </main>
+  )
+}

--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -19,7 +19,7 @@ export default function LoginPage() {
     if (res.ok) {
       const data = await res.json()
       localStorage.setItem('token', data.token)
-      router.push('/dashboard')
+      router.push('/loading?next=/dashboard')
     } else {
       alert('Login failed')
     }

--- a/client/src/app/signup/page.tsx
+++ b/client/src/app/signup/page.tsx
@@ -21,7 +21,7 @@ export default function SignUpPage() {
     if (res.ok) {
       const data = await res.json()
       localStorage.setItem('token', data.token)
-      router.push('/profile')
+      router.push('/loading?next=/profile')
     } else {
       alert('Signup failed')
     }

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -2,9 +2,10 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 
 export default function Navbar() {
+  const pathname = usePathname()
   const [loggedIn, setLoggedIn] = useState(false)
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null)
   const [username, setUsername] = useState('')
@@ -12,6 +13,7 @@ export default function Navbar() {
   const router = useRouter()
 
   useEffect(() => {
+    if (pathname === '/loading') return
     const token = localStorage.getItem('token')
     const isLogged = !!token
     setLoggedIn(isLogged)
@@ -27,7 +29,9 @@ export default function Navbar() {
         })
         .catch(() => {})
     }
-  }, [])
+  }, [pathname])
+
+  if (pathname === '/loading') return null
 
   const handleSignOut = async () => {
     localStorage.removeItem('token')


### PR DESCRIPTION
## Summary
- add a `/loading` route that fetches profile data
- redirect to this screen after login and signup
- hide `Navbar` while the loading page is displayed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686618cb44408321b03dbfa5660c42f7