### PR TITLE
Enhance quiz form placeholders and homepage description

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -4,6 +4,13 @@ export default function Page() {
   return (
     <main className={styles.main}>
       <h1 className="text-2xl font-bold">AI Interview Prep Quizzer</h1>
+      <p className="mt-2 max-w-xl">
+        Created by Calvin Moldenhauer, this app generates custom interview quizzes
+        so you can practice for technical roles. Select a role, tech stack or
+        paste a job listing and the AI will build questions tailored to your
+        needs. Our mission is to make focused interview prep quick and
+        accessible.
+      </p>
     </main>
   )
 }

--- a/client/src/app/quiz/page.tsx
+++ b/client/src/app/quiz/page.tsx
@@ -67,34 +67,34 @@ export default function QuizStartPage() {
         <h1 className="text-2xl font-bold">Start Quiz</h1>
         <input
           type="text"
-          placeholder="Role"
+          placeholder="Role \u2013 e.g. Frontend Developer, QA Engineer (optional)"
           className="border p-2 w-full"
           value={role}
           onChange={(e) => setRole(e.target.value)}
         />
         <input
           type="text"
-          placeholder="Tech Stack"
+          placeholder="Tech Stack \u2013 e.g. MERN, LAMP (optional)"
           className="border p-2 w-full"
           value={techStack}
           onChange={(e) => setTechStack(e.target.value)}
         />
         <input
           type="text"
-          placeholder="Technologies"
+          placeholder="Technologies \u2013 e.g. React, Docker (optional)"
           className="border p-2 w-full"
           value={technology}
           onChange={(e) => setTechnology(e.target.value)}
         />
         <textarea
-          placeholder="Listing Description"
+          placeholder="Listing Description \u2013 e.g. develop APIs, maintain infra (optional)"
           className="border p-2 w-full"
           value={listingDescription}
           onChange={(e) => setListingDescription(e.target.value)}
         />
         <input
           type="url"
-          placeholder="Job Description URL"
+          placeholder="Job Description URL \u2013 e.g. https://example.com/job, https://jobs.site/id (optional)"
           className="border p-2 w-full"
           value={jobDescriptionUrl}
           onChange={(e) => setJobDescriptionUrl(e.target.value)}


### PR DESCRIPTION
## Summary
- add mission description to the main page
- show example placeholders for each quiz input

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68661b7df2f8832192418fe7f02282a0