### PR TITLE
Add labels and style homepage

### DIFF
--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -29,14 +29,18 @@ export default function LoginPage() {
     <main className={styles.main}>
       <form onSubmit={handleSubmit} className="space-y-4">
         <h1 className="text-2xl font-bold">Login</h1>
+        <label htmlFor="email" className="block">Email</label>
         <input
+          id="email"
           type="email"
           placeholder="Email"
           className="border p-2 w-full"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
         />
+        <label htmlFor="password" className="block">Password</label>
         <input
+          id="password"
           type="password"
           placeholder="Password"
           className="border p-2 w-full"

--- a/client/src/app/page.module.css
+++ b/client/src/app/page.module.css
@@ -1,3 +1,7 @@
 .main {
   @apply flex flex-grow items-center justify-center p-4 text-center;
 }
+
+.card {
+  @apply border p-6 bg-white rounded shadow max-w-xl;
+}

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -3,14 +3,16 @@ import styles from './page.module.css'
 export default function Page() {
   return (
     <main className={styles.main}>
-      <h1 className="text-2xl font-bold">AI Interview Prep Quizzer</h1>
-      <p className="mt-2 max-w-xl">
-        Created by Calvin Moldenhauer, this app generates custom interview quizzes
-        so you can practice for technical roles. Select a role, tech stack or
-        paste a job listing and the AI will build questions tailored to your
-        needs. Our mission is to make focused interview prep quick and
-        accessible.
-      </p>
+      <div className={styles.card}>
+        <h1 className="text-2xl font-bold">AI Interview Prep Quizzer</h1>
+        <p className="mt-2 max-w-xl">
+          Created by Calvin Moldenhauer, this app generates custom interview quizzes
+          so you can practice for technical roles. Select a role, tech stack or
+          paste a job listing and the AI will build questions tailored to your
+          needs. Our mission is to make focused interview prep quick and
+          accessible.
+        </p>
+      </div>
     </main>
   )
 }

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -76,20 +76,26 @@ export default function ProfilePage() {
           {avatarUrl && (
             <img src={avatarUrl} alt="avatar" className="h-24 w-24 rounded-full" />
           )}
+          <label htmlFor="avatar" className="block">Avatar</label>
           <input
+            id="avatar"
             aria-label="avatar"
             type="file"
             accept="image/*"
             onChange={(e) => setAvatar(e.target.files?.[0] || null)}
           />
+          <label htmlFor="username" className="block">Username</label>
           <input
+            id="username"
             type="text"
             placeholder="Username"
             className="border p-2 w-full"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
           />
+          <label htmlFor="bio" className="block">Bio</label>
           <textarea
+            id="bio"
             placeholder="Bio"
             className="border p-2 w-full"
             value={bio}

--- a/client/src/app/quiz/page.tsx
+++ b/client/src/app/quiz/page.tsx
@@ -65,34 +65,44 @@ export default function QuizStartPage() {
     <main className={styles.main}>
       <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md">
         <h1 className="text-2xl font-bold">Start Quiz</h1>
+        <label htmlFor="role" className="block">Role</label>
         <input
+          id="role"
           type="text"
           placeholder="Role \u2013 e.g. Frontend Developer, QA Engineer (optional)"
           className="border p-2 w-full"
           value={role}
           onChange={(e) => setRole(e.target.value)}
         />
+        <label htmlFor="techStack" className="block">Tech Stack</label>
         <input
+          id="techStack"
           type="text"
           placeholder="Tech Stack \u2013 e.g. MERN, LAMP (optional)"
           className="border p-2 w-full"
           value={techStack}
           onChange={(e) => setTechStack(e.target.value)}
         />
+        <label htmlFor="technology" className="block">Technologies</label>
         <input
+          id="technology"
           type="text"
           placeholder="Technologies \u2013 e.g. React, Docker (optional)"
           className="border p-2 w-full"
           value={technology}
           onChange={(e) => setTechnology(e.target.value)}
         />
+        <label htmlFor="listing" className="block">Listing Description</label>
         <textarea
+          id="listing"
           placeholder="Listing Description \u2013 e.g. develop APIs, maintain infra (optional)"
           className="border p-2 w-full"
           value={listingDescription}
           onChange={(e) => setListingDescription(e.target.value)}
         />
+        <label htmlFor="jobUrl" className="block">Job Description URL</label>
         <input
+          id="jobUrl"
           type="url"
           placeholder="Job Description URL \u2013 e.g. https://example.com/job, https://jobs.site/id (optional)"
           className="border p-2 w-full"

--- a/client/src/app/signup/page.tsx
+++ b/client/src/app/signup/page.tsx
@@ -31,21 +31,27 @@ export default function SignUpPage() {
     <main className={styles.main}>
       <form onSubmit={handleSubmit} className="space-y-4">
         <h1 className="text-2xl font-bold">Sign Up</h1>
+        <label htmlFor="username" className="block">Username</label>
         <input
+          id="username"
           type="text"
           placeholder="Username"
           className="border p-2 w-full"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
         />
+        <label htmlFor="email" className="block">Email</label>
         <input
+          id="email"
           type="email"
           placeholder="Email"
           className="border p-2 w-full"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
         />
+        <label htmlFor="password" className="block">Password</label>
         <input
+          id="password"
           type="password"
           placeholder="Password"
           className="border p-2 w-full"


### PR DESCRIPTION
## Summary
- style homepage with centered card layout
- add explicit labels to login, signup, profile and quiz pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68661d9088f4832188aa154f319c2c55