### PR TITLE
Improve profile layout and quiz actions

### DIFF
--- a/client/src/app/profile/page.module.css
+++ b/client/src/app/profile/page.module.css
@@ -1,3 +1,7 @@
 .main {
-  @apply flex flex-grow items-center justify-center p-4;
+  @apply flex flex-col flex-grow items-center p-4 gap-6;
+}
+
+.section {
+  @apply w-full max-w-md text-center mt-6;
 }

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -71,7 +71,7 @@ export default function ProfilePage() {
   return (
     <main className={styles.main}>
       {editing ? (
-        <form onSubmit={handleSubmit} className="space-y-4" encType="multipart/form-data">
+        <form onSubmit={handleSubmit} className="space-y-4 text-center" encType="multipart/form-data">
           <h1 className="text-2xl font-bold">Edit Profile</h1>
           {avatarUrl && (
             <img src={avatarUrl} alt="avatar" className="h-24 w-24 rounded-full" />
@@ -111,14 +111,16 @@ export default function ProfilePage() {
           {avatarUrl && (
             <img src={avatarUrl} alt="avatar" className="h-24 w-24 rounded-full mx-auto" />
           )}
-          <h1 className="text-2xl font-bold">{username}</h1>
+          <h1 className="text-2xl font-semibold">{username}</h1>
           <p>{bio}</p>
-          <button className="bg-blue-500 text-white px-4 py-2" onClick={() => setEditing(true)}>Edit Profile</button>
+          <button className="bg-blue-500 text-white px-4 py-2" onClick={() => setEditing(true)}>
+            Edit Profile
+          </button>
         </div>
       )}
         {sessions.length > 0 && (
-          <section className="mt-8 w-full max-w-md">
-            <h2 className="text-xl font-bold mb-2">Open Quizzes</h2>
+          <section className={styles.section}>
+            <h2 className="text-xl font-semibold mb-2">Open Quizzes</h2>
             <ul className="space-y-1 mb-4">
               {sessions
                 .filter((s) => s.correctCount < s.totalQuestions)
@@ -130,7 +132,7 @@ export default function ProfilePage() {
                   </li>
                 ))}
             </ul>
-            <h2 className="text-xl font-bold mb-2">Finished Quizzes</h2>
+            <h2 className="text-xl font-semibold mb-2">Finished Quizzes</h2>
             <ul className="space-y-1">
               {sessions
                 .filter((s) => s.correctCount === s.totalQuestions)

--- a/client/src/app/quiz/session/[id]/summary/page.tsx
+++ b/client/src/app/quiz/session/[id]/summary/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
+import Loader from '../../../../components/Loader'
 import styles from './page.module.css'
 
 interface Question {
@@ -22,19 +23,30 @@ export default function QuizSummaryPage() {
   const router = useRouter()
   const [data, setData] = useState<SessionData | null>(null)
   const [loading, setLoading] = useState(true)
+  const [actionLoading, setActionLoading] = useState(false)
 
   const handleRetake = async () => {
-    const res = await fetch(`/api/session/${id}/reset`, { method: 'POST' })
-    if (res.ok) {
-      router.push(`/quiz/session/${id}`)
+    setActionLoading(true)
+    try {
+      const res = await fetch(`/api/session/${id}/reset`, { method: 'POST' })
+      if (res.ok) {
+        router.push(`/quiz/session/${id}`)
+      }
+    } finally {
+      setActionLoading(false)
     }
   }
 
   const handleNew = async () => {
-    const res = await fetch(`/api/session/${id}/new`, { method: 'POST' })
-    if (res.ok) {
-      const data = await res.json()
-      router.push(`/quiz/session/${data.sessionId}`)
+    setActionLoading(true)
+    try {
+      const res = await fetch(`/api/session/${id}/new`, { method: 'POST' })
+      if (res.ok) {
+        const data = await res.json()
+        router.push(`/quiz/session/${data.sessionId}`)
+      }
+    } finally {
+      setActionLoading(false)
     }
   }
 
@@ -87,17 +99,25 @@ export default function QuizSummaryPage() {
       <div className="flex gap-2 mt-4">
         <button
           onClick={handleRetake}
-          className="bg-blue-500 text-white px-3 py-1"
+          disabled={actionLoading}
+          className="bg-blue-500 text-white px-3 py-1 disabled:opacity-50"
         >
           Retake Quiz
         </button>
         <button
           onClick={handleNew}
-          className="bg-green-500 text-white px-3 py-1"
+          disabled={actionLoading}
+          className="bg-green-500 text-white px-3 py-1 disabled:opacity-50"
         >
           New Questions
         </button>
       </div>
+      {actionLoading && (
+        <div className="flex flex-col items-center mt-4" data-testid="action-loading">
+          <Loader />
+          <p className="mt-2">Loading...</p>
+        </div>
+      )}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- center profile layout with better spacing
- show quiz lists under profile info
- add loader when retaking quiz or requesting new questions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686620d8e1588321a18a1992afb07ef1