### PR TITLE
Prepare Vercel deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration
+OPENAI_API_KEY=your-openai-api-key
+JWT_SECRET=change-me
+DATABASE_URL=file:./dev.db

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ an avatar and short bio.
    npm run lint
    npm test
    ```
+5. Configure environment variables by copying `.env.example` to `.env` and updating the values.
 
 The application stores user data in a SQLite database using Prisma. After cloning
 the repo you can inspect the `client/prisma/schema.prisma` file which describes
@@ -62,3 +63,23 @@ the database models. New fields can be added and migrations generated with
   profile.
 - **Testing:** Jest and React Testing Library are configured inside `client/` to
   ensure pages behave as expected.
+
+## Deployment with Vercel
+
+1. Ensure you have the Vercel CLI installed or run it with `npx`:
+   ```bash
+   npm install -g vercel # optional
+   ```
+2. Sign in to Vercel:
+   ```bash
+   vercel login
+   ```
+3. Set the required environment variables in Vercel:
+   - `OPENAI_API_KEY`
+   - `JWT_SECRET`
+   - `DATABASE_URL` (e.g. `file:./dev.db` for the bundled SQLite database)
+4. Deploy from the repository root using the provided script:
+   ```bash
+   ./deploy.sh
+   ```
+   The script calls `vercel --prod` with the project located in the `client/` directory.

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "vercel-build": "prisma migrate deploy && prisma generate && next build"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -1,6 +1,6 @@
 datasource db {
   provider = "sqlite"
-  url      = "file:../dev.db"
+  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Deploy the Next.js app on Vercel
+npx vercel --prod --cwd client "$@"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "builds": [{ "src": "client/next.config.mjs", "use": "@vercel/next" }],
+  "routes": [{ "src": "/(.*)", "dest": "client/$1" }]
+}


### PR DESCRIPTION
## Summary
- add a `vercel-build` script that runs migrations and builds
- add Vercel configuration and a helper deployment script
- allow configuring Prisma via `DATABASE_URL`
- document environment variables and Vercel deployment steps
- provide `.env.example` template

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68663af7bb588321ac0b117f61cb30c8