### PR TITLE
Fix nodemailer dependency and add verification migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ an avatar and short bio.
    npm run lint
    npm test
    ```
-5. Configure environment variables by copying `.env.example` to `.env` and updating the values.
+5. Configure environment variables by copying `.env.example` to `.env` and updating the values. In addition to `OPENAI_API_KEY`, `JWT_SECRET` and `DATABASE_URL`, set the SMTP values used in `src/lib/email.ts` (`EMAIL_HOST`, `EMAIL_USER`, `EMAIL_PASS`) and Google OAuth (`GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`). After modifying the schema run `npx prisma migrate dev` to apply the new migration for the verification fields.
 
 The application stores user data in a SQLite database using Prisma. After cloning
 the repo you can inspect the `client/prisma/schema.prisma` file which describes

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "google-auth-library": "^10.1.0",
         "jsonwebtoken": "^9.0.2",
         "next": "14.2.0",
+        "nodemailer": "^7.0.4",
         "openai": "^4.20.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -9330,6 +9331,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.4.tgz",
+      "integrity": "sha512-9O00Vh89/Ld2EcVCqJ/etd7u20UhME0f/NToPfArwPEe1Don1zy4mAIz6ariRr7mJ2RDxtaDzN0WJVdVXPtZaw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "google-auth-library": "^10.1.0",
     "jsonwebtoken": "^9.0.2",
     "next": "14.2.0",
+    "nodemailer": "^7.0.4",
     "openai": "^4.20.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/client/prisma/migrations/20250703020000_add_verification_fields/migration.sql
+++ b/client/prisma/migrations/20250703020000_add_verification_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "isVerified" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN "verificationCode" TEXT;

--- a/client/src/app/loading/page.tsx
+++ b/client/src/app/loading/page.tsx
@@ -19,7 +19,7 @@ export default function LoadingScreen() {
     fetch('/api/user/profile', { headers: { 'x-user-id': userId } })
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then(() => {
-        const next = params.get('next') || '/dashboard'
+        const next = params?.get('next') || '/dashboard'
         router.replace(next)
       })
       .catch(() => {

--- a/client/src/app/signup/verify/page.tsx
+++ b/client/src/app/signup/verify/page.tsx
@@ -6,7 +6,7 @@ import styles from '../page.module.css'
 
 export default function VerifyPage() {
   const params = useSearchParams()
-  const email = params.get('email') || ''
+  const email = params?.get('email') || ''
   const [code, setCode] = useState('')
   const router = useRouter()
 

--- a/client/src/pages/api/auth/index.ts
+++ b/client/src/pages/api/auth/index.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
-import prisma from '../../lib/db'
-import { sendEmail } from '../../lib/email'
+import prisma from '../../../lib/db'
+import { sendEmail } from '../../../lib/email'
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret'
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -30,7 +30,7 @@
       }
     ],
     "strictNullChecks": true,
-    "types": ["jest"]
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- add `nodemailer` dependency
- patch auth API imports
- migrate user verification fields
- handle optional search params
- reference new env vars and migrations in README
- include jest-dom types

## Testing
- `npm test`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68664dbd95f08321ac8ec02064777eee