### PR TITLE
Improve Google sign-in buttons

### DIFF
--- a/client/src/app/login/page.module.css
+++ b/client/src/app/login/page.module.css
@@ -1,3 +1,3 @@
 .main {
-  @apply flex flex-grow items-center justify-center p-4;
+  @apply flex flex-grow items-center justify-center p-4 text-center;
 }

--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -26,7 +26,7 @@ export default function LoginPage() {
 
   return (
     <main className={styles.main}>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md mx-auto text-center">
         <h1 className="text-2xl font-bold">Login</h1>
         <label htmlFor="email" className="block">Email</label>
         <input
@@ -46,16 +46,18 @@ export default function LoginPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2">
-          Login
-        </button>
-        <button
-          type="button"
-          className="bg-red-500 text-white px-4 py-2 w-full"
-          onClick={() => signIn('google')}
-        >
-          Sign in with Google
-        </button>
+        <div className="flex justify-center gap-2">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+            Login
+          </button>
+          <button
+            type="button"
+            className="bg-red-500 text-white px-4 py-2"
+            onClick={() => signIn('google', { callbackUrl: '/dashboard' })}
+          >
+            Sign in with Google
+          </button>
+        </div>
       </form>
     </main>
   )

--- a/client/src/app/signup/page.module.css
+++ b/client/src/app/signup/page.module.css
@@ -1,3 +1,3 @@
 .main {
-  @apply flex flex-grow items-center justify-center p-4;
+  @apply flex flex-grow items-center justify-center p-4 text-center;
 }

--- a/client/src/app/signup/page.tsx
+++ b/client/src/app/signup/page.tsx
@@ -28,7 +28,7 @@ export default function SignUpPage() {
 
   return (
     <main className={styles.main}>
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md mx-auto text-center">
         <h1 className="text-2xl font-bold">Sign Up</h1>
         <label htmlFor="username" className="block">Username</label>
         <input
@@ -57,19 +57,19 @@ export default function SignUpPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2">
-          Sign Up
-        </button>
+        <div className="flex justify-center gap-2">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+            Sign Up
+          </button>
+          <button
+            type="button"
+            className="bg-red-500 text-white px-4 py-2"
+            onClick={() => signIn('google', { callbackUrl: '/profile' })}
+          >
+            Sign up with Google
+          </button>
+        </div>
       </form>
-      <div className="mt-4">
-        <button
-          type="button"
-          className="bg-red-500 text-white px-4 py-2 w-full"
-          onClick={() => signIn('google')}
-        >
-          Sign up with Google
-        </button>
-      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- align `Login` and `Sign Up` pages with a cleaner layout
- place Google auth buttons next to the primary action buttons
- redirect after OAuth and update styling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68675e522a708321ada81e1a70bf47b4