### PR TITLE
Fix Google OAuth sign-in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ an avatar and short bio.
    npm run lint
    npm test
    ```
-5. Configure environment variables by copying `.env.example` to `.env` and updating the values. In addition to `OPENAI_API_KEY`, `JWT_SECRET` and `DATABASE_URL`, set the SMTP values used in `src/lib/email.ts` (`EMAIL_HOST`, `EMAIL_USER`, `EMAIL_PASS`) and Google OAuth (`GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`). After modifying the schema run `npx prisma migrate dev` to apply the new migration for the verification fields.
+5. Configure environment variables for the Next.js app by copying `client/.env.example` to `client/.env.local` and filling in the values. In addition to `OPENAI_API_KEY`, `JWT_SECRET` and `DATABASE_URL`, set the SMTP values used in `src/lib/email.ts` (`EMAIL_HOST`, `EMAIL_USER`, `EMAIL_PASS`) and Google OAuth (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`). After modifying the schema run `npx prisma migrate dev` to apply the new migration for the verification fields.
 
 The application stores user data in a SQLite database using Prisma. After cloning
 the repo you can inspect the `client/prisma/schema.prisma` file which describes

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration
+OPENAI_API_KEY=your-openai-api-key
+JWT_SECRET=change-me
+DATABASE_URL=file:./dev.db
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=


### PR DESCRIPTION
## Summary
- add environment variable example to `client` folder
- clarify README instructions for creating `client/.env.local`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686779a6a2048321b7ce5b9cd8252c73