### PR TITLE
Fix answer validation for multiple choice

### DIFF
--- a/client/src/pages/api/answer.ts
+++ b/client/src/pages/api/answer.ts
@@ -26,6 +26,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(404).json({ error: 'Question not found' })
     }
 
+    if (question.options) {
+      const correct =
+        question.modelAnswer.trim().toLowerCase() ===
+        answer.trim().toLowerCase()
+
+      await prisma.question.update({
+        where: { id: questionId },
+        data: { userCorrect: correct },
+      })
+      if (correct) {
+        await prisma.session.update({
+          where: { id: question.sessionId },
+          data: { correctCount: { increment: 1 } },
+        })
+      }
+
+      return res.status(200).json({ correct })
+    }
+
     const prompt = `You are an expert technical interviewer evaluating a candidate's answer.\\n` +
       `Question: ${question.prompt}\\n` +
       `Candidate Answer: ${answer}\\n` +


### PR DESCRIPTION
## Summary
- compare user's choice to the stored correct option before using OpenAI

## Testing
- `npm ci --omit=optional`
- `npm test` *(fails: downloading swc package requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68681092e75c8321b644ba0c66fb461b