### PR TITLE
Fix multiple-choice answers to match full model response

### DIFF
--- a/client/src/pages/api/answer.ts
+++ b/client/src/pages/api/answer.ts
@@ -27,9 +27,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (question.options) {
+      const normalizedModel = question.modelAnswer.trim().toLowerCase()
+      const normalizedAnswer = answer.trim().toLowerCase()
       const correct =
-        question.modelAnswer.trim().toLowerCase() ===
-        answer.trim().toLowerCase()
+        normalizedModel === normalizedAnswer ||
+        normalizedModel.includes(normalizedAnswer)
 
       await prisma.question.update({
         where: { id: questionId },

--- a/client/src/pages/api/quiz.ts
+++ b/client/src/pages/api/quiz.ts
@@ -105,8 +105,15 @@ export default async function handler(
         correctCount: 0,
         questions: {
           create: prompts.map((p: any) => {
-            const opts = p.options ? [...p.options] : null
-            if (opts) shuffle(opts)
+            let opts = p.options ? [...p.options] : null
+            if (opts) {
+              // ensure the full answer is selectable by replacing the first
+              // option with the answer text before shuffling
+              if (p.answer) {
+                opts[0] = p.answer
+              }
+              shuffle(opts)
+            }
             return {
               prompt: p.prompt || p,
               hint: p.hint || '',

--- a/client/src/pages/api/session/[id]/new.ts
+++ b/client/src/pages/api/session/[id]/new.ts
@@ -56,8 +56,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         correctCount: 0,
         questions: {
           create: prompts.map((p: any) => {
-            const opts = p.options ? [...p.options] : null
-            if (opts) shuffle(opts)
+            let opts = p.options ? [...p.options] : null
+            if (opts) {
+              // ensure the correct answer option contains the full answer text
+              if (p.answer) {
+                opts[0] = p.answer
+              }
+              shuffle(opts)
+            }
             return {
               prompt: p.prompt || p,
               hint: p.hint || '',


### PR DESCRIPTION
## Summary
- use full answer text as the first option before shuffling
- accept an option as correct if it matches or is contained in the model answer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686818911a5c83219277914dad5d7b3c