### PR TITLE
Add quiz proficiency option

### DIFF
--- a/client/prisma/migrations/20250704000000_add_proficiency/migration.sql
+++ b/client/prisma/migrations/20250704000000_add_proficiency/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "proficiency" TEXT NOT NULL DEFAULT 'Medium';

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Session {
   userId         String
   user           User       @relation(fields: [userId], references: [id])
   role           String
+  proficiency    String    @default("Medium")
   multipleChoice Boolean   @default(false)
   totalQuestions Int
   correctCount   Int

--- a/client/src/app/quiz/page.tsx
+++ b/client/src/app/quiz/page.tsx
@@ -19,6 +19,7 @@ export default function QuizStartPage() {
   const [listingDescription, setListingDescription] = useState('')
   const [jobDescriptionUrl, setJobDescriptionUrl] = useState('')
   const [multipleChoice, setMultipleChoice] = useState(false)
+  const [proficiency, setProficiency] = useState('Medium')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const router = useRouter()
@@ -54,6 +55,7 @@ export default function QuizStartPage() {
         listingDescription,
         jobDescriptionUrl,
         multipleChoice,
+        proficiency,
       }),
     })
     setLoading(false)
@@ -112,6 +114,17 @@ export default function QuizStartPage() {
           value={jobDescriptionUrl}
           onChange={(e) => setJobDescriptionUrl(e.target.value)}
         />
+        <label htmlFor="proficiency" className="block text-2xl">Proficiency</label>
+        <select
+          id="proficiency"
+          className="border p-2 w-full"
+          value={proficiency}
+          onChange={(e) => setProficiency(e.target.value)}
+        >
+          <option value="Beginner">Beginner</option>
+          <option value="Medium">Medium</option>
+          <option value="Advanced">Advanced</option>
+        </select>
         <label className="flex items-center gap-2">
           <input
             type="checkbox"

--- a/client/src/app/quiz/session/[id]/summary/page.tsx
+++ b/client/src/app/quiz/session/[id]/summary/page.tsx
@@ -15,6 +15,7 @@ interface SessionData {
   questions: Question[]
   correctCount: number
   totalQuestions: number
+  proficiency: string
 }
 
 export default function QuizSummaryPage() {
@@ -80,6 +81,7 @@ export default function QuizSummaryPage() {
   return (
     <main className={styles.main}>
       <h1 className="text-2xl font-bold mb-4">Quiz Summary</h1>
+      <p className="mb-2">Difficulty: {data.proficiency}</p>
       <p className="mb-4">
         Correct {data.correctCount} of {data.totalQuestions}
       </p>

--- a/client/src/pages/api/quiz.ts
+++ b/client/src/pages/api/quiz.ts
@@ -12,6 +12,7 @@ interface QuizRequest {
   listingDescription?: string
   jobDescriptionUrl?: string
   multipleChoice?: boolean
+  proficiency?: string
 }
 
 export default async function handler(
@@ -26,6 +27,7 @@ export default async function handler(
     listingDescription,
     jobDescriptionUrl,
     multipleChoice = false,
+    proficiency = 'Medium',
   } = req.body as QuizRequest
 
   if (
@@ -70,6 +72,7 @@ export default async function handler(
     (technology ? `Technologies: ${technology}.\n` : '') +
     (listingDescription ? `Listing Description: ${listingDescription}.\n` : '') +
     (jobDescription ? `Job Description: ${jobDescription.slice(0, 1000)}\n` : '') +
+    `Difficulty: ${proficiency}.\n` +
     (multipleChoice
       ? '\nReturn JSON array where each item has "prompt", "hint", "answer", and "options" (an array of 6 strings with the first option as the correct answer).'
       : '\nReturn JSON array where each item has "prompt", "hint", and "answer".')
@@ -100,6 +103,7 @@ export default async function handler(
       data: {
         userId,
         role: role || 'developer',
+        proficiency,
         multipleChoice,
         totalQuestions: prompts.length,
         correctCount: 0,

--- a/client/src/pages/api/session/[id]/new.ts
+++ b/client/src/pages/api/session/[id]/new.ts
@@ -23,7 +23,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ error: err.message })
     }
 
-    const prompt = `Generate 5 interview questions for a ${session.role} role.\n` +
+    const prompt =
+      `Generate 5 interview questions for a ${session.role} role.\n` +
+      `Difficulty: ${session.proficiency}.\n` +
       (session.multipleChoice
         ? '\nReturn JSON array where each item has "prompt", "hint", "answer", and "options" (an array of 6 strings with the first option as the correct answer).'
         : '\nReturn JSON array where each item has "prompt", "hint", and "answer".')
@@ -51,6 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       data: {
         userId: session.userId,
         role: session.role,
+        proficiency: session.proficiency,
         multipleChoice: session.multipleChoice,
         totalQuestions: prompts.length,
         correctCount: 0,

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -12,6 +12,7 @@ export interface Session {
   id: string
   userId: string
   role: string
+  proficiency: string
   totalQuestions: number
   correctCount: number
   createdAt: Date


### PR DESCRIPTION
## Summary
- allow selecting quiz proficiency and default to Medium
- include proficiency in quiz generation requests
- persist proficiency to session DB model and display in summary
- add migration for new proficiency column

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868479e7f0c832182eb216a8e337777