### PR TITLE
Improve quiz loader

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/client/src/app/quiz/page.module.css
+++ b/client/src/app/quiz/page.module.css
@@ -1,3 +1,7 @@
 .main {
   @apply flex flex-col flex-grow items-center p-4 gap-4;
 }
+
+.robot {
+  font-family: 'Orbitron', sans-serif;
+}

--- a/client/src/app/quiz/page.tsx
+++ b/client/src/app/quiz/page.tsx
@@ -71,7 +71,13 @@ export default function QuizStartPage() {
 
   return (
     <main className={styles.main}>
-      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md">
+      {loading ? (
+        <div className="mt-10 flex flex-col items-center" data-testid="loading">
+          <p className={`text-2xl font-bold mb-4 ${styles.robot}`}>Terminator Processing RAW DATA</p>
+          <Loader />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md">
         <h1 className="text-2xl font-bold text-center">Create Quiz</h1>
         <AutocompleteInput
           id="role"
@@ -137,13 +143,8 @@ export default function QuizStartPage() {
           Generate Quiz
         </button>
       </form>
-      {loading && (
-        <div className="mt-4 text-center" data-testid="loading">
-          <Loader />
-          <p className="mt-2">Generating questions...</p>
-        </div>
       )}
-      {error && <p className="mt-2 text-red-500">{error}</p>}
+      {error && !loading && <p className="mt-2 text-red-500">{error}</p>}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- show loader while quiz is generating and hide the form
- add Orbitron font import and style class for robot text
- display "Terminator Processing RAW DATA" above loader

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68685863744083219230cbb2f9a89776