### PR TITLE
Fix quiz session completion status

### DIFF
--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -130,7 +130,7 @@ export default function ProfilePage() {
             <h2 className="text-xl font-semibold mb-2">Open Quizzes</h2>
             <ul className="space-y-1 mb-4">
               {sessions
-                .filter((s) => s.correctCount < s.totalQuestions)
+                .filter((s) => s.answeredCount < s.totalQuestions)
                 .map((s) => (
                   <li key={s.id}>
                     <Link className="underline" href={`/quiz/session/${s.id}`}>{`
@@ -142,7 +142,7 @@ export default function ProfilePage() {
             <h2 className="text-xl font-semibold mb-2">Finished Quizzes</h2>
             <ul className="space-y-1">
               {sessions
-                .filter((s) => s.correctCount === s.totalQuestions)
+                .filter((s) => s.answeredCount === s.totalQuestions)
                 .map((s) => (
                   <li key={s.id}>
                     <Link className="underline" href={`/quiz/session/${s.id}/summary`}>{`

--- a/client/src/pages/api/user/profile.ts
+++ b/client/src/pages/api/user/profile.ts
@@ -14,7 +14,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      include: { sessions: true },
+      include: {
+        sessions: {
+          include: { questions: { select: { userCorrect: true } } },
+        },
+      },
     })
     if (!user) return res.status(404).json({ error: 'User not found' })
 
@@ -29,6 +33,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         multipleChoice: s.multipleChoice,
         totalQuestions: s.totalQuestions,
         correctCount: s.correctCount,
+        answeredCount: s.questions.filter(
+          (q) => q.userCorrect !== null && q.userCorrect !== undefined
+        ).length,
       })),
     })
   } catch (err) {


### PR DESCRIPTION
## Summary
- include question completion details in user profile API
- show finished quizzes based on answered count rather than correct answers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686872025e6c8321b2666ef54fc57318