### PR TITLE
Add API token request management

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ the database models. New fields can be added and migrations generated with
   profile.
 - **Testing:** Jest and React Testing Library are configured inside `client/` to
   ensure pages behave as expected.
+- **API Access Management:** users can request access to the shared OpenAI token
+  from their profile page. Administrators can grant or revoke access from the
+  admin dashboard, and quiz generation checks these permissions.
 
 ## Deployment with Vercel
 

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -15,6 +15,8 @@ model User {
   avatarUrl String?
   bio       String?
   role      String
+  apiAccess Boolean   @default(false)
+  accessRequested Boolean @default(false)
   isVerified Boolean  @default(false)
   verificationCode String?
   sessions  Session[]    // one-to-many → Session.user

--- a/client/src/app/admin/page.tsx
+++ b/client/src/app/admin/page.tsx
@@ -8,6 +8,8 @@ interface User {
   id: string
   email: string
   username: string
+  apiAccess: boolean
+  accessRequested: boolean
   sessions: { id: string; role: string }[]
 }
 
@@ -25,6 +27,23 @@ export default function AdminPage() {
       .catch(() => router.replace('/'))
   }, [router, session, status])
 
+  const updateAccess = async (id: string, grant: boolean) => {
+    const res = await fetch('/api/admin/users', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, apiAccess: grant }),
+    })
+    if (res.ok) {
+      setUsers((prev) =>
+        prev.map((u) =>
+          u.id === id ? { ...u, apiAccess: grant, accessRequested: false } : u
+        )
+      )
+    } else {
+      alert('Update failed')
+    }
+  }
+
   return (
     <main className={styles.main}>
       <h1 className="text-2xl font-bold mb-4">All Users</h1>
@@ -37,6 +56,23 @@ export default function AdminPage() {
                 <li key={s.id}>{s.role}</li>
               ))}
             </ul>
+            <div className="mt-2">
+              {u.apiAccess ? (
+                <button
+                  className="px-2 py-1 bg-red-500 text-white"
+                  onClick={() => updateAccess(u.id, false)}
+                >
+                  Revoke Access
+                </button>
+              ) : (
+                <button
+                  className="px-2 py-1 bg-green-500 text-white"
+                  onClick={() => updateAccess(u.id, true)}
+                >
+                  {u.accessRequested ? 'Approve Request' : 'Grant Access'}
+                </button>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -14,6 +14,8 @@ export default function ProfilePage() {
   const [bio, setBio] = useState('')
   const [sessions, setSessions] = useState<any[]>([])
   const [editing, setEditing] = useState(false)
+  const [apiAccess, setApiAccess] = useState(false)
+  const [accessRequested, setAccessRequested] = useState(false)
   const router = useRouter()
   const { data: session, status } = useSession()
 
@@ -30,6 +32,8 @@ export default function ProfilePage() {
         setBio(data.bio || '')
         setAvatarUrl(data.avatarUrl || null)
         setSessions(data.sessions || [])
+        setApiAccess(!!data.apiAccess)
+        setAccessRequested(!!data.accessRequested)
       })
       .catch((err) => console.error('Profile fetch error', err))
   }, [router, session, status])
@@ -60,6 +64,16 @@ export default function ProfilePage() {
       setEditing(false)
     } else {
       alert('Profile update failed')
+    }
+  }
+
+  const requestAccess = async () => {
+    const res = await fetch('/api/user/request-token', { method: 'POST' })
+    if (res.ok) {
+      alert('Access requested')
+      setAccessRequested(true)
+    } else {
+      alert('Request failed')
     }
   }
 
@@ -123,6 +137,21 @@ export default function ProfilePage() {
           <button className="bg-blue-500 text-white px-4 py-2" onClick={() => setEditing(true)}>
             Edit Profile
           </button>
+          <div className="mt-4">
+            {apiAccess ? (
+              <p className="text-green-600 font-semibold">You have API access.</p>
+            ) : accessRequested ? (
+              <p className="text-yellow-600">Access request pending.</p>
+            ) : (
+              <button
+                type="button"
+                className="bg-blue-500 text-white px-4 py-2"
+                onClick={requestAccess}
+              >
+                Request API Access
+              </button>
+            )}
+          </div>
         </div>
       )}
         {sessions.length > 0 && (

--- a/client/src/pages/api/admin/users.ts
+++ b/client/src/pages/api/admin/users.ts
@@ -4,7 +4,6 @@ import { getServerSession } from 'next-auth/next'
 import { authOptions } from '../auth/[...nextauth]'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'GET') return res.status(405).end()
   const session = await getServerSession(req, res, authOptions)
   const userId = session?.user?.id as string | undefined
   if (!userId) return res.status(401).json({ error: 'Unauthorized' })
@@ -14,8 +13,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(403).json({ error: 'Forbidden' })
   }
 
-  const users = await prisma.user.findMany({
-    include: { sessions: true },
-  })
-  res.status(200).json({ users })
+  if (req.method === 'GET') {
+    const users = await prisma.user.findMany({
+      include: { sessions: true },
+    })
+    return res.status(200).json({ users })
+  }
+
+  if (req.method === 'PATCH') {
+    const { id, apiAccess } = req.body as { id?: string; apiAccess?: boolean }
+    if (!id || apiAccess === undefined) {
+      return res.status(400).json({ error: 'Missing parameters' })
+    }
+    await prisma.user.update({
+      where: { id },
+      data: { apiAccess, accessRequested: false },
+    })
+    return res.status(200).json({ success: true })
+  }
+
+  res.status(405).end()
 }

--- a/client/src/pages/api/quiz.ts
+++ b/client/src/pages/api/quiz.ts
@@ -46,6 +46,11 @@ export default async function handler(
     return res.status(401).json({ error: 'Unauthorized' })
   }
 
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user || (!user.apiAccess && user.role !== 'admin')) {
+    return res.status(403).json({ error: 'API access required' })
+  }
+
   try {
     await enforceQuizQuota(userId)
   } catch (err) {

--- a/client/src/pages/api/user/profile.ts
+++ b/client/src/pages/api/user/profile.ts
@@ -27,6 +27,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       bio: user.bio,
       avatarUrl: user.avatarUrl,
       role: user.role,
+      apiAccess: user.apiAccess,
+      accessRequested: user.accessRequested,
       sessions: user.sessions.map((s) => ({
         id: s.id,
         role: s.role,

--- a/client/src/pages/api/user/request-token.ts
+++ b/client/src/pages/api/user/request-token.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import prisma from '../../../lib/db'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '../auth/[...nextauth]'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  const session = await getServerSession(req, res, authOptions)
+  const userId = session?.user?.id as string | undefined
+  if (!userId) return res.status(401).json({ error: 'Unauthorized' })
+
+  try {
+    await prisma.user.update({
+      where: { id: userId },
+      data: { accessRequested: true },
+    })
+    res.status(200).json({ success: true })
+  } catch (err) {
+    console.error('TOKEN REQUEST ERROR:', err)
+    res.status(500).json({ error: 'Failed to request access' })
+  }
+}


### PR DESCRIPTION
## Summary
- extend `User` model for API access flags
- add token request API endpoint
- expose API access data in profile API
- block quiz generation without access
- allow admins to manage API access
- show access request UI on profile
- show grant/revoke buttons on admin page
- document API access management in README

## Testing
- `npm --prefix client run lint`
- `npm --prefix client test`
- `npx --prefix client prisma validate` *(fails: Error: Failed to fetch sha256 checksum)*

------
https://chatgpt.com/codex/tasks/task_e_686d4f343c7c83219ac2a48871113b56