### PR TITLE
Fix option truncation bug

### DIFF
--- a/client/src/pages/api/quiz.ts
+++ b/client/src/pages/api/quiz.ts
@@ -122,16 +122,6 @@ export default async function handler(
               if (p.answer) {
                 opts[0] = p.answer.trim()
               }
-              const others = opts.slice(1)
-              if (others.length) {
-                const avg = others.reduce((a, b) => a + b.length, 0) / others.length
-                if (opts[0].length > avg * 1.5) {
-                  const shortened = opts[0]
-                    .slice(0, Math.ceil(avg * 1.2))
-                    .replace(/\s+\S*$/, '')
-                  opts[0] = `${shortened}...`
-                }
-              }
               shuffle(opts)
             }
             return {


### PR DESCRIPTION
## Summary
- remove logic that shortened correct answers

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d57cdcb8c8321b12d9ed3ec42e2a6