### PR TITLE
Fix vercel build path and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ the database models. New fields can be added and migrations generated with
    - `OPENAI_API_KEY`
    - `JWT_SECRET`
   - `DATABASE_URL` (the PostgreSQL connection string from your Supabase project)
-4. Deploy from the repository root using the provided script:
+4. Deploy the project using the script inside the `client` directory:
    ```bash
-   ./deploy.sh
+   client/deploy.sh
    ```
-   The script calls `vercel --prod` with the project located in the `client/` directory.
+   The script runs `vercel --prod` and sets the working directory to `client/`.

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
-  "builds": [{ "src": "client/next.config.mjs", "use": "@vercel/next" }],
+  "builds": [{ "src": "client/package.json", "use": "@vercel/next" }],
   "routes": [{ "src": "/(.*)", "dest": "client/$1" }]
 }


### PR DESCRIPTION
## Summary
- point vercel.json to `client/package.json`
- clarify deploy instructions in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686daf3a0aac8321818a29eb393dd75f